### PR TITLE
Fix undo when creating collisions

### DIFF
--- a/Gann4Games/Ragdoll Factory/Scripts/States/BoxColliderComponentState.cs
+++ b/Gann4Games/Ragdoll Factory/Scripts/States/BoxColliderComponentState.cs
@@ -35,17 +35,15 @@ namespace Gann4Games.RagdollFactory.States
             collisionObject.transform.localPosition = Vector3.zero;
             collisionObject.transform.forward = objB.position - objA.position;
             collisionObject.transform.localScale = Vector3.one;
-            BoxCollider _selectedBoxCollider = Undo.AddComponent<BoxCollider>(collisionObject);
+            BoxCollider _selectedBoxCollider = collisionObject.AddComponent<BoxCollider>();
             _selectedBoxCollider.center = Vector3.forward * height;
             _selectedBoxCollider.size = new Vector3(Context.boxColliderWidth, Context.boxColliderDepth, distance);
             
             Context.boxColliderLength = height;
             
             Undo.RegisterCreatedObjectUndo(collisionObject, "Created Box Collider Object");
-            Undo.RegisterCompleteObjectUndo(Context, "Created Box Collider Object");
-
-
             Select(_selectedBoxCollider);
+            Undo.RegisterCompleteObjectUndo(Context, "Created Box Collider Object");
         }
 
         public override void ConvertTo(Component component)

--- a/Gann4Games/Ragdoll Factory/Scripts/States/CapsuleColliderComponentState.cs
+++ b/Gann4Games/Ragdoll Factory/Scripts/States/CapsuleColliderComponentState.cs
@@ -32,13 +32,13 @@ namespace Gann4Games.RagdollFactory.States
             //     throw new Exception("The second bone must be child of the first bone!");
             
             float distance = Vector3.Distance(objA.position, objB.position);
-            
+
             GameObject collisionObject = new GameObject(objA.name + " - " + objB.name);
             collisionObject.transform.SetParent(objA);
             collisionObject.transform.localPosition = Vector3.zero;
             collisionObject.transform.forward = objB.position - objA.position;
             collisionObject.transform.localScale = Vector3.one;
-            CapsuleCollider selectedCapsuleCollider = Undo.AddComponent<CapsuleCollider>(collisionObject);
+            CapsuleCollider selectedCapsuleCollider = collisionObject.AddComponent<CapsuleCollider>();
             selectedCapsuleCollider.direction = 2;
             selectedCapsuleCollider.radius = Context.capsuleColliderRadius;
             selectedCapsuleCollider.center = Vector3.forward * distance / 2;
@@ -46,9 +46,9 @@ namespace Gann4Games.RagdollFactory.States
             
             Context.capsuleColliderLength = distance;
             
-            Undo.RegisterCompleteObjectUndo(Context, "Created Capsule Collider Object");
-            
+            Undo.RegisterCreatedObjectUndo(collisionObject, "Created Capsule Collider Object");
             Select(selectedCapsuleCollider);
+            Undo.RegisterCompleteObjectUndo(Context, "Created Capsule Collider Object");
         }
 
         public override void ConvertTo(Component component)


### PR DESCRIPTION
Whenever a new collision object was created and then pressed CTRL - Z to try and fix it, the collision component was removed, however the new created object was not getting removed, making the ragdoll factory mistake that object for a skeleton bone (which isn't true, therefore connecting joints to this object will lead to broken motion)